### PR TITLE
Update default value of `fileChunkSizeBytes` param

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pipelines:
           # Size of a file chunk in bytes to split large files, maximum is 4MB.
           # Type: int
           # Required: no
-          fileChunkSizeBytes: "4194304"
+          fileChunkSizeBytes: "3932160"
           # Timeout for Dropbox longpolling requests.
           # Type: duration
           # Required: no

--- a/connector.yaml
+++ b/connector.yaml
@@ -64,7 +64,7 @@ specification:
       - name: fileChunkSizeBytes
         description: Size of a file chunk in bytes to split large files, maximum is 4MB.
         type: int
-        default: "4194304"
+        default: "3932160"
         validations: []
       - name: longpollTimeout
         description: Timeout for Dropbox longpolling requests.

--- a/source/config.go
+++ b/source/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	// Timeout for Dropbox longpolling requests.
 	LongpollTimeout time.Duration `json:"longpollTimeout" default:"30s"`
 	// Size of a file chunk in bytes to split large files, maximum is 4MB.
-	FileChunkSizeBytes uint64 `json:"fileChunkSizeBytes" default:"4194304"`
+	FileChunkSizeBytes uint64 `json:"fileChunkSizeBytes" default:"3932160"`
 	// Maximum number of retry attempts.
 	Retries int `json:"retries" default:"0"`
 	// Delay between retry attempts.


### PR DESCRIPTION
### Description

Updated default value of fileChunkSizeBytes to 3.75MB to stay within gRPC’s 4MB message limit, accounting for record metadata and overhead.

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-dropbox/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.